### PR TITLE
Disable laser emitter from dynamic reconfigure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ include_directories(include
                     ${catkin_INCLUDE_DIRS}
                     ${Boost_INCLUDE_DIRS}
                     ${CMAKE_CURRENT_BINARY_DIR}/openni2/include
+                    ${CMAKE_CURRENT_BINARY_DIR}/openni2/Include
                     )
 
 

--- a/cfg/Astra.cfg
+++ b/cfg/Astra.cfg
@@ -50,5 +50,7 @@ gen.add("z_scaling", double_t, 0, "Scaling factor for depth values", 1.0, 0.5, 1
 
 gen.add("use_device_time", bool_t, 0, "Use internal timer of OpenNI device", True)
 
+gen.add("disable_emitter", bool_t, 0, "Disable laser emitter", False)
+
 exit(gen.generate(PACKAGE, "Astra", "Astra"))
 

--- a/include/astra_camera/astra_device.h
+++ b/include/astra_camera/astra_device.h
@@ -78,6 +78,8 @@ public:
 
   bool isValid() const;
 
+  bool setEmitterState(bool state) const;
+
   bool hasIRSensor() const;
   bool hasColorSensor() const;
   bool hasDepthSensor() const;

--- a/include/astra_camera/astra_driver.h
+++ b/include/astra_camera/astra_driver.h
@@ -174,6 +174,9 @@ private:
 
   bool use_device_time_;
 
+  bool disable_emitter_;
+  bool emitter_disabled_;
+
   Config old_config_;
 };
 

--- a/src/astra_device.cpp
+++ b/src/astra_device.cpp
@@ -31,6 +31,7 @@
  */
 
 #include "openni2/OpenNI.h"
+#include <openni2/PS1080.h>
 
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string/replace.hpp>
@@ -132,6 +133,19 @@ const std::string AstraDevice::getStringID() const
 bool AstraDevice::isValid() const
 {
   return (openni_device_.get() != 0) && openni_device_->isValid();
+}
+
+bool AstraDevice::setEmitterState(bool state) const
+{
+  OniBool bEmitterState = (state ? TRUE : FALSE);
+  openni::Status rc = openni_device_->setProperty(XN_MODULE_PROPERTY_EMITTER_STATE, (uint8_t*)&bEmitterState, sizeof(bEmitterState));
+
+  if (rc != openni::STATUS_OK)
+  {
+    return false;
+  }
+
+  return true;
 }
 
 float AstraDevice::getIRFocalLength(int output_y_resolution) const


### PR DESCRIPTION
Adds a reconfigurable option to disable laser emitter when viewing IR image stream

Note that when switching to the IR stream, the astra camera re-enables the emitter, even if `disable_emitter `is checked. However, If `disable_emitter` is selected, then the emitter will be very quickly disabled (first IR frame callback).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/ros_astra_camera/3)
<!-- Reviewable:end -->
