### PR TITLE
Prevent depth image mode from unsetting IR emitter toggle

### DIFF
--- a/include/astra_camera/astra_driver.h
+++ b/include/astra_camera/astra_driver.h
@@ -174,8 +174,9 @@ private:
 
   bool use_device_time_;
 
-  bool disable_emitter_;
-  bool emitter_disabled_;
+  bool set_emitter_disabled_;
+  bool depth_emitter_disabled_;
+  bool ir_emitter_disabled_;
 
   Config old_config_;
 };

--- a/src/astra_driver.cpp
+++ b/src/astra_driver.cpp
@@ -59,8 +59,9 @@ AstraDriver::AstraDriver(ros::NodeHandle& n, ros::NodeHandle& pnh) :
     color_subscribers_(false),
     depth_subscribers_(false),
     depth_raw_subscribers_(false),
-    disable_emitter_(false),
-    emitter_disabled_(false)
+    set_emitter_disabled_(false),
+    ir_emitter_disabled_(false),
+    depth_emitter_disabled_(false)
 {
 
   genVideoModeTableMap();
@@ -192,14 +193,17 @@ void AstraDriver::configCb(Config &config, uint32_t level)
   if (config_init_ && old_config_.rgb_preferred != config.rgb_preferred)
     imageConnectCb();
 
-  if (disable_emitter_ != config.disable_emitter){
-    disable_emitter_ = config.disable_emitter;
+  if (set_emitter_disabled_ != config.disable_emitter){
+    set_emitter_disabled_ = config.disable_emitter;
 
-    // If there are active IR streams and emitter is currently disabled, enable
-    if (!disable_emitter_ && device_->isIRStreamStarted())
+    // If there are active IR/depth streams and the desired emitter state has changed from disabled to not disabled, emitter should be enabled
+    if (!set_emitter_disabled_ && (device_->isIRStreamStarted() || device_->isDepthStreamStarted()))
     {
-      device_->setEmitterState(true);
-      emitter_disabled_ = false;
+      if (device_->setEmitterState(true))
+      {
+        depth_emitter_disabled_ = false;
+        ir_emitter_disabled_ = false;
+      }
     }
   }
 
@@ -377,7 +381,8 @@ void AstraDriver::imageConnectCb()
     {
       ROS_INFO("Stopping IR stream.");
       device_->stopIRStream();
-      emitter_disabled_ = false;
+      ir_emitter_disabled_ = false;
+      depth_emitter_disabled_ = false;
     }
 
     if (!color_started)
@@ -419,7 +424,8 @@ void AstraDriver::imageConnectCb()
     {
       ROS_INFO("Stopping IR stream.");
       device_->stopIRStream();
-      emitter_disabled_ = false;
+      ir_emitter_disabled_ = false;
+      depth_emitter_disabled_ = false;
     }
   }
 }
@@ -444,15 +450,19 @@ void AstraDriver::depthConnectCb()
   {
     ROS_INFO("Stopping depth stream.");
     device_->stopDepthStream();
+    ir_emitter_disabled_ = false;
+    depth_emitter_disabled_ = false;
   }
 }
 
 void AstraDriver::newIRFrameCallback(sensor_msgs::ImagePtr image)
 {
-  if (disable_emitter_ && !emitter_disabled_)
+  if (set_emitter_disabled_ && !ir_emitter_disabled_)
   {
-    device_->setEmitterState(false);
-    emitter_disabled_ = true;
+    if(device_->setEmitterState(false))
+    {
+      ir_emitter_disabled_ = true;
+    }
   }
 
   if ((++data_skip_ir_counter_)%data_skip_==0)
@@ -487,6 +497,13 @@ void AstraDriver::newColorFrameCallback(sensor_msgs::ImagePtr image)
 
 void AstraDriver::newDepthFrameCallback(sensor_msgs::ImagePtr image)
 {
+  if (set_emitter_disabled_ && !depth_emitter_disabled_)
+  {
+    if(device_->setEmitterState(false)){
+      depth_emitter_disabled_ = true;
+    }
+  }
+
   if ((++data_skip_depth_counter_)%data_skip_==0)
   {
 


### PR DESCRIPTION
Astra camera enables emitter whenever subscribing to depth image. This code takes into account depth image stream when changing emitter (making the changes stick)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/ros_astra_camera/4)
<!-- Reviewable:end -->
