### PR TITLE
Get the astra driver to exit if it can't find a device

### DIFF
--- a/src/astra_driver.cpp
+++ b/src/astra_driver.cpp
@@ -801,7 +801,7 @@ std::string AstraDriver::resolveDeviceURI(const std::string& device_id) throw(As
 
     // everything else is treated as part of the device_URI
     bool match_found = false;
-    std::string matched_uri;
+    std::string matched_uri = "INVALID";
     for (size_t i = 0; i < available_device_URIs->size(); ++i)
     {
       std::string s = (*available_device_URIs)[i];
@@ -845,9 +845,8 @@ void AstraDriver::initDevice()
     {
       if (!device_)
       {
-        ROS_INFO("No matching device found.... waiting for devices. Reason: %s", exception.what());
-        boost::this_thread::sleep(boost::posix_time::seconds(3));
-        continue;
+        ROS_ERROR("No matching device found.... Reason: %s", exception.what());
+        throw;
       }
       else
       {


### PR DESCRIPTION
Without this change the driver would switch to finding ANY device, which
meant that if one camera had a wrong ID (or more commonly the hardware
didn't come up), it could steal another camera. So we could end up with
the "frontcenter" node owning the proximity_front camera which effectively
makes both of them useless!

Another (bad) possiblity is that the proximity_front camera could claim
some other camera and then we would try to drive with _very_ invalid data.

In addition to fixing the assignment problem described above, this change,
when combined with a change to the launch file to make the driver a
"required" nodelet, will allow systemd to manage the shutdown, restart,
recovery of the cameras individually.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/ros_astra_camera/5)
<!-- Reviewable:end -->
