### PR TITLE
Corrected dynamic reconfigure limits for IR shift

### DIFF
--- a/cfg/Astra.cfg
+++ b/cfg/Astra.cfg
@@ -42,8 +42,8 @@ gen.add("ir_time_offset", double_t, 0, "ir image time offset in seconds", -0.033
 gen.add("color_time_offset", double_t, 0, "color image time offset in seconds", -0.033, -1.0, 1.0 );
 gen.add("depth_time_offset", double_t, 0, "depth image time offset in seconds", -0.033, -1.0, 1.0 );
 
-gen.add("depth_ir_offset_x", double_t, 0, "X offset between IR and depth images", 5.0, -10.0, 10.0)
-gen.add("depth_ir_offset_y", double_t, 0, "Y offset between IR and depth images", 4.0, -10.0, 10.0)
+gen.add("depth_ir_offset_x", double_t, 0, "X offset between IR and depth images", 5.0, -20.0, 20.0)
+gen.add("depth_ir_offset_y", double_t, 0, "Y offset between IR and depth images", 4.0, -20.0, 20.0)
 
 gen.add("z_offset_mm", int_t, 0, "Z offset in mm", 0, -200, 200)
 gen.add("z_scaling", double_t, 0, "Scaling factor for depth values", 1.0, 0.5, 1.5)


### PR DESCRIPTION
The IR shift for the depth image is thresholded to +/- 10 pixels. However, the orbbec astra mini S has a shift that between 13 and 16 pixels

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/ros_astra_camera/6)
<!-- Reviewable:end -->
