### PR TITLE
add orbbec repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "astra_openni2/OpenNI2"]
+	path = astra_openni2/OpenNI2
+	url = git@github.com:BadgerTechnologies/OpenNI2.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,9 +17,9 @@ include(ExternalProject)
 
 ExternalProject_Add(astra_openni2
   PREFIX astra_openni2
-  # SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/astra_openni2/OpenNI2
-  GIT_REPOSITORY https://github.com/orbbec/OpenNI2.git
-  GIT_TAG orbbec_ros
+  SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/astra_openni2/OpenNI2
+  #GIT_REPOSITORY https://github.com/orbbec/OpenNI2.git
+  #GIT_TAG orbbec_ros
   CONFIGURE_COMMAND echo "no need to configure"
   #${CMAKE_CURRENT_SOURCE_DIR}/libantlr/configure --prefix=<INSTALL_DIR>
   BUILD_IN_SOURCE 1


### PR DESCRIPTION
I added OpenNI2 as a submodule as it was being downloaded from github each build.  This way it will reside with the source repo and the version will be locked as opposed to fetching the latest commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/ros_astra_camera/8)
<!-- Reviewable:end -->
