### PR TITLE
astra_driver: don't leak fds or use when invalid

### DIFF
--- a/src/astra_driver.cpp
+++ b/src/astra_driver.cpp
@@ -80,15 +80,19 @@ AstraDriver::AstraDriver(ros::NodeHandle& n, ros::NodeHandle& pnh) :
       {
           ROS_ERROR("Lock file \"%s\" could not be opened: %s", lockFileName.c_str(), strerror(errno));
       }
-      if (flock(fd, LOCK_EX) < 0)
+      else
       {
-          ROS_ERROR("Unable to lock file \"%s\": %s", lockFileName.c_str(), strerror(errno));
-      }
-      ROS_INFO("File locked for camera %s", device_id_.c_str());
-      initDevice();
-      if (flock(fd, LOCK_UN) < 0)
-      {
-          ROS_ERROR("Cannot unlock file \"%s\"!: %s", lockFileName.c_str(), strerror(errno));
+          if (flock(fd, LOCK_EX) < 0)
+          {
+              ROS_ERROR("Unable to lock file \"%s\": %s", lockFileName.c_str(), strerror(errno));
+          }
+          ROS_INFO("File locked for camera %s", device_id_.c_str());
+          initDevice();
+          if (flock(fd, LOCK_UN) < 0)
+          {
+              ROS_ERROR("Cannot unlock file \"%s\"!: %s", lockFileName.c_str(), strerror(errno));
+          }
+          close(fd);
       }
   }
   else


### PR DESCRIPTION
While this code technically did check the return code of open it would
go ahead and use it anyway even if it failed. Additionally if it
succeeded it would never close the file descriptor. This means it would
leak the file descriptor. In the crazy case the unlock failed for some
reason closing the file descriptor would also work to unlock it since
locks only apply to open file descriptors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/ros_astra_camera/9)
<!-- Reviewable:end -->
