### PR TITLE
astra_camera: add signal handler to allow clean shutdown

### DIFF
--- a/ros/astra_camera_node.cpp
+++ b/ros/astra_camera_node.cpp
@@ -31,12 +31,23 @@
  */
 
 #include "astra_camera/astra_driver.h"
+#include <signal.h>
+
+void term_handler(int sig) {
+  ros::requestShutdown();
+}
 
 int main(int argc, char **argv){
 
   ros::init(argc, argv, "astra_camera");
   ros::NodeHandle n;
   ros::NodeHandle pnh("~");
+  /*
+   * handle SIGTERM and SIGINT so that we can shutdown cleanly. We have seen
+   * cameras get into bad states when this is not shutdown cleanly.
+   */
+  signal(SIGINT, term_handler);
+  signal(SIGTERM, term_handler);
 
   astra_wrapper::AstraDriver drv(n, pnh);
 

--- a/ros/astra_camera_nodelet.cpp
+++ b/ros/astra_camera_nodelet.cpp
@@ -32,6 +32,11 @@
 
 #include "astra_camera/astra_driver.h"
 #include <nodelet/nodelet.h>
+#include <signal.h>
+
+void term_handler(int sig) {
+  ros::requestShutdown();
+}
 
 namespace astra_camera
 {
@@ -46,6 +51,12 @@ public:
 private:
   virtual void onInit()
   {
+    /*
+     * handle SIGTERM and SIGINT so that we can shutdown cleanly. We have seen
+     * cameras get into bad states when this is not shutdown cleanly.
+     */
+    signal(SIGTERM, term_handler);
+    signal(SIGINT, term_handler);
     lp.reset(new astra_wrapper::AstraDriver(getNodeHandle(), getPrivateNodeHandle()));
   };
 


### PR DESCRIPTION
When this node/nodelet is stopped it can sometimes leave the camera is a
bad state where the only solution is to restart the camera itself. The
only way to restart the camera is to restart the whole system or
phsyically unplug the camera. Since both of those solutions are
impractical a solution that prevents us from ever entering that state is
needed.

By adding a signal handler and telling ros to shutdown we should allow
the camera to get shutdown more cleanly and less abrubtly. Testing shows
that this seems to reduce the number of times that we get the camera
into a bad state.

We handle both SIGINT and SIGTERM because the nodelet will sent SIGINT
first followed by SIGTERM. This should give us enough time to cleanly
shut everything down. If both of these timeout it will eventually send
SIGKILL, which we can't handle, and we will not get to shutdown cleanly.
We generally do have enough time to shutdown though before that happens.

It would be great if the underlying issue with the devices was fixed but
this should help for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/ros_astra_camera/10)
<!-- Reviewable:end -->
