### PR TITLE
Query stored intrinsics from Gemini cameras

### DIFF
--- a/include/astra_camera/astra_device_type.h
+++ b/include/astra_camera/astra_device_type.h
@@ -4,13 +4,15 @@
 #define OB_STEREO_S "Orbbec Canglong"
 #define OB_EMBEDDED_S "Astra SL1000S_U3"
 #define OB_ASTRA_PRO "Orbbec Astra Pro"
+#define OB_STEREO_S3 "Astra SV1301S_U3"
 
 typedef enum
 {
     OB_ASTRA_NO,
     OB_STEREO_S_NO,
     OB_EMBEDDED_S_NO,
-    OB_ASTRA_PRO_NO
+    OB_ASTRA_PRO_NO,
+    OB_STEREO_S3_NO
 } OB_DEVICE_NO;
 
 bool astraWithUVC(OB_DEVICE_NO id);

--- a/src/astra_device.cpp
+++ b/src/astra_device.cpp
@@ -103,6 +103,10 @@ AstraDevice::AstraDevice(const std::string& device_URI):
   {
     device_type_no = OB_ASTRA_PRO_NO;
   }
+  else if (strcmp(device_type, OB_STEREO_S3) == 0)
+  {
+    device_type_no = OB_STEREO_S3_NO;
+  }
   else
   {
     device_type_no = OB_ASTRA_NO;

--- a/src/astra_device_type.cpp
+++ b/src/astra_device_type.cpp
@@ -2,7 +2,7 @@
 
 bool astraWithUVC(OB_DEVICE_NO id)
 {
-    if (id == OB_STEREO_S_NO || id == OB_EMBEDDED_S_NO || id == OB_ASTRA_PRO_NO)
+    if (id == OB_STEREO_S_NO || id == OB_EMBEDDED_S_NO || id == OB_ASTRA_PRO_NO || id == OB_STEREO_S3_NO)
         return true;
     return false;
 }


### PR DESCRIPTION
Gemini was not listed as a supported device, so astra camera was
defaulting to generating standard intrinsics derived from reported
focal length and idealized pinhole model.

Note: The focal length for gemini devices is incorrectly reported
to be ~5 degrees. This is only an issue when using default
intrinsics.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/ros_astra_camera/14)
<!-- Reviewable:end -->
