### PR TITLE
Add default video mode for stereo S3 (ROS-570)

### DIFF
--- a/src/astra_driver.cpp
+++ b/src/astra_driver.cpp
@@ -339,7 +339,9 @@ bool AstraDriver::setIRFloodCb(astra_camera::SetIRFloodRequest& req, astra_camer
 
 void AstraDriver::configCb(Config &config, uint32_t level)
 {
-  if (device_->getDeviceTypeNo() == OB_STEREO_S_NO)
+  OB_DEVICE_NO device_num = device_->getDeviceTypeNo();
+
+  if (device_num == OB_STEREO_S_NO || device_num == OB_STEREO_S3_NO)
   {
     if (config.depth_mode != 13 && config.depth_mode != 14)
     {
@@ -350,7 +352,7 @@ void AstraDriver::configCb(Config &config, uint32_t level)
       config.ir_mode = 13;
     }
   }
-  else if (device_->getDeviceTypeNo() == OB_EMBEDDED_S_NO)
+  else if (device_num == OB_EMBEDDED_S_NO)
   {
     if (config.depth_mode != 13 && config.depth_mode != 17)
     {


### PR DESCRIPTION
Prior versions of stereo S3 cameras inaccurately reported available
video modes. Firmware for later versions of the camera seems to
have been updated to accurately report available video modes
(matching those of the stereo S camera)

The mismatch in requested and reported video modes for later
versions of the stereo S3 cameras crashed the driver. This commit
resolves the issue by ensuring that default video modes match those
of the stereo S camera.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/ros_astra_camera/15)
<!-- Reviewable:end -->
