### PR TITLE
Disable LDP by default

### DIFF
--- a/cfg/Astra.cfg
+++ b/cfg/Astra.cfg
@@ -56,6 +56,7 @@ gen.add("z_scaling", double_t, 0, "Scaling factor for depth values", 1.0, 0.5, 1
 gen.add("use_device_time", bool_t, 0, "Use internal timer of OpenNI device", True)
 
 gen.add("disable_emitter", bool_t, 0, "Disable laser emitter", False)
+gen.add("disable_ldp", bool_t, 0, "Disable proximity sensor", True)
 
 exit(gen.generate(PACKAGE, "Astra", "Astra"))
 

--- a/src/astra_driver.cpp
+++ b/src/astra_driver.cpp
@@ -420,6 +420,11 @@ void AstraDriver::configCb(Config &config, uint32_t level)
     }
   }
 
+  if (!config_init_ || config.disable_ldp != old_config_.disable_ldp)
+  {
+    device_->setLDP(!config.disable_ldp);
+  }
+
   depth_ir_offset_x_ = config.depth_ir_offset_x;
   depth_ir_offset_y_ = config.depth_ir_offset_y;
   z_offset_mm_ = config.z_offset_mm;


### PR DESCRIPTION
The proximity (LDP) sensor on the stereo S U3 cameras is being triggered by the covers for some robots, effectively disabling the sensor. This commit makes LDP reconfigurable, and disables it by default.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/ros_astra_camera/16)
<!-- Reviewable:end -->
