### PR TITLE
Only disable proximity (LDP) sensor for stereo S U3 devices

### DIFF
--- a/src/astra_device.cpp
+++ b/src/astra_device.cpp
@@ -268,16 +268,6 @@ void AstraDevice::setLDP(bool enable)
   {
     openni_device_->setProperty(XN_MODULE_PROPERTY_LDP_ENABLE, (uint8_t *)&enable_, 4);
   }
-  else
-  {
-    boost::shared_ptr<openni::VideoStream> depth_stream = getDepthVideoStream();
-    boost::shared_ptr<openni::VideoStream> ir_stream = getIRVideoStream();
-    depth_stream->stop();
-    ir_stream->stop();
-    openni_device_->setProperty(openni::OBEXTENSION_ID_LDP_EN, (uint8_t *)&enable_, 4);
-    depth_stream->start();
-    ir_stream->start();
-  }
 }
 
 void AstraDevice::switchIRCamera(int cam)


### PR DESCRIPTION
When LDP is disabled, astra will also attempt to update devices
without LDP sensors, and this somehow puts the RGB camera into
a bad state. Let's not do this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/ros_astra_camera/17)
<!-- Reviewable:end -->
