### PR TITLE
Fix modify-after-publish bug

### DIFF
--- a/src/astra_driver.cpp
+++ b/src/astra_driver.cpp
@@ -838,7 +838,9 @@ void AstraDriver::newDepthFrameCallback(sensor_msgs::ImagePtr image)
         // Update camera info timestamp to match current frame
         depth_camera_info_->header.stamp = image->header.stamp;
 
-        pub_depth_raw_.publish(image, depth_camera_info_);
+        // Make copy to avoid modify-after-publish on next iteration
+        sensor_msgs::CameraInfoPtr info(new sensor_msgs::CameraInfo(*depth_camera_info_));
+        pub_depth_raw_.publish(image, info);
       }
 
       if (depth_subscribers_ )
@@ -848,7 +850,9 @@ void AstraDriver::newDepthFrameCallback(sensor_msgs::ImagePtr image)
         // Update camera info timestamp to match current frame
         depth_camera_info_->header.stamp = image->header.stamp;
 
-        pub_depth_.publish(floating_point_image, depth_camera_info_);
+        // Make copy to avoid modify-after-publish on next iteration
+        sensor_msgs::CameraInfoPtr info(new sensor_msgs::CameraInfo(*depth_camera_info_));
+        pub_depth_.publish(floating_point_image, info);
       }
 
       // Projector "info" probably only useful for working with disparity images
@@ -856,7 +860,10 @@ void AstraDriver::newDepthFrameCallback(sensor_msgs::ImagePtr image)
       {
         // Update camera info timestamp to match current frame
         projector_camera_info_->header.stamp = image->header.stamp;
-        pub_projector_info_.publish(projector_camera_info_);
+
+        // Make copy to avoid modify-after-publish on next iteration
+        sensor_msgs::CameraInfoPtr info(new sensor_msgs::CameraInfo(*projector_camera_info_));
+        pub_projector_info_.publish(info);
       }
     }
   }


### PR DESCRIPTION
The camera driver was modifying the time stamp on the same camera_info object each time it published an image via image_transport. This means that, if it takes more than one full frame period for the message to get serialized to external subscribers, it is possible for the next iteration to modify the timestamp before it went out.  This was observed when Rviz subscribed to a throttled image topic over wifi. It could cause the cameara_infos pulished by the throttled node to be off by one image period, so that they never match exactly with the timestamp in the image messages so that image_transport was would become unsynchronized for throttled images. This could cause the auto-floor-leveling to never work, since it uses throttled topics, which could prevent floor calibration from working, since it waits for the auto-floor-leveler.

ROS-1531 ("Unable to do depthcam floor calibration due to image_transport unsynchronized") ROS-376 ("Front proximity depthcam placement -> calibration issue")

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BadgerTechnologies/ros_astra_camera/20)
<!-- Reviewable:end -->
