### PR TITLE
Add service for getting camera URI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ add_message_files(
 add_service_files(
   FILES
   GetSerial.srv
+  GetUri.srv
   GetDeviceInfo.srv
   GetDeviceType.srv
   GetIRGain.srv

--- a/include/astra_camera/astra_driver.h
+++ b/include/astra_camera/astra_driver.h
@@ -53,6 +53,7 @@
 #include "astra_camera/astra_device.h"
 #include "astra_camera/astra_video_mode.h"
 #include "astra_camera/GetSerial.h"
+#include "astra_camera/GetUri.h"
 #include "astra_camera/GetDeviceInfo.h"
 #include "astra_camera/GetDeviceType.h"
 #include "astra_camera/GetIRGain.h"
@@ -107,6 +108,7 @@ private:
   void depthConnectCb();
 
   bool getSerialCb(astra_camera::GetSerialRequest& req, astra_camera::GetSerialResponse& res);
+  bool getUriCb(astra_camera::GetUriRequest& req, astra_camera::GetUriResponse& res);
   bool getDeviceInfoCb(astra_camera::GetDeviceInfoRequest& req, astra_camera::GetDeviceInfoResponse& res);
   bool getDeviceTypeCb(astra_camera::GetDeviceTypeRequest& req, astra_camera::GetDeviceTypeResponse& res);
   bool getIRGainCb(astra_camera::GetIRGainRequest& req, astra_camera::GetIRGainResponse& res);
@@ -150,6 +152,7 @@ private:
   /** \brief get_serial server*/
   ros::ServiceServer get_camera_info;
   ros::ServiceServer get_serial_server;
+  ros::ServiceServer get_uri_server;
   ros::ServiceServer get_device_info_server;
   ros::ServiceServer get_device_type_server;
   ros::ServiceServer get_ir_gain_server;

--- a/src/astra_driver.cpp
+++ b/src/astra_driver.cpp
@@ -259,6 +259,7 @@ void AstraDriver::advertiseROSTopics()
   }
 
   get_serial_server = nh_.advertiseService("get_serial", &AstraDriver::getSerialCb, this);
+  get_uri_server = nh_.advertiseService("get_uri", &AstraDriver::getUriCb, this);
   get_device_info_server = nh_.advertiseService("get_device_info", &AstraDriver::getDeviceInfoCb, this);
   get_device_type_server = nh_.advertiseService("get_device_type", &AstraDriver::getDeviceTypeCb, this);
   get_ir_gain_server = nh_.advertiseService("get_ir_gain", &AstraDriver::getIRGainCb, this);
@@ -280,6 +281,12 @@ void AstraDriver::advertiseROSTopics()
 bool AstraDriver::getSerialCb(astra_camera::GetSerialRequest& req, astra_camera::GetSerialResponse& res)
 {
   res.serial = device_manager_->getSerial(device_->getUri());
+  return true;
+}
+
+bool AstraDriver::getUriCb(astra_camera::GetUriRequest& req, astra_camera::GetUriResponse& res)
+{
+  res.uri = device_->getUri();
   return true;
 }
 

--- a/srv/GetUri.srv
+++ b/srv/GetUri.srv
@@ -1,0 +1,2 @@
+---
+string uri


### PR DESCRIPTION
Astra Minis do not have a unique serial number in their udev information, meaning the only way to determine what port they are in is to get the busnum and devnum from the URI.

Added a rosservice that will return the URI.

ROS-1680: Wellink USB Hub: Write named yaml files for
          depthcams

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BadgerTechnologies/ros_astra_camera/21)
<!-- Reviewable:end -->
